### PR TITLE
Get lock on instance creation

### DIFF
--- a/internal/implementation_cgo/implementation.go
+++ b/internal/implementation_cgo/implementation.go
@@ -162,6 +162,8 @@ type mainPdfium struct {
 }
 
 func (p *mainPdfium) GetInstance() *PdfiumImplementation {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 	newInstance := &PdfiumImplementation{
 		logger:                          p.logger,
 		documentRefs:                    map[references.FPDF_DOCUMENT]*DocumentHandle{},
@@ -195,7 +197,6 @@ func (p *mainPdfium) GetInstance() *PdfiumImplementation {
 		glyphPathRefs:                   map[references.FPDF_GLYPHPATH]*GlyphPathHandle{},
 		fileReaders:                     map[string]*fileReaderRef{},
 	}
-
 	newInstance.instanceRef = len(p.instanceRefs)
 	p.instanceRefs[newInstance.instanceRef] = newInstance
 


### PR DESCRIPTION
# Background

Running into race conditions when calling `pool.GetInstance` in a single threaded environment

Looks like we want to acquire a lock here on the main pdfium instance when getting the instance. 

That being said, maybe I'm not meant to be calling `pool.GetInstance` in the way I am to get an instance from a single threaded pool:

```
func foo() {
	// Acquire the PDFium instance (resource lock) from the pool before reading the data
	instance, err := pool.GetInstance(60 * time.Second)

	if err != nil {
		return nil, fmt.Errorf("failed to acquire pdfium instance: %w", err)
	}

	// Ensure that the instance is closed (returned to the pool) after processing.
	defer func() {
		if instanceCloseErr := instance.Close(); instanceCloseErr != nil {
			log.Printf("Error closing PDF instance: %v", instanceCloseErr)
		}
	}()
```

Even if this is not what I'm meant to do though, it feels like this lock should still be in the `implementation.go` function this PR addresses to maintain thread safety there

##  Error logs
```
scanner-1  | fatal error: concurrent map writes
scanner-1  |
scanner-1  | goroutine 7544 [running]:
scanner-1  | internal/runtime/maps.fatal({0x2bb31dc?, 0x40046fe530?})
scanner-1  | 	/usr/local/go/src/runtime/panic.go:1053 +0x20
scanner-1  | github.com/klippa-app/go-pdfium/internal/implementation_cgo.(*mainPdfium).GetInstance(0x519a320)
scanner-1  | 	/go/pkg/mod/github.com/klippa-app/go-pdfium@v1.14.0/internal/implementation_cgo/implementation.go:200 +0x624
scanner-1  | github.com/klippa-app/go-pdfium/single_threaded.(*pdfiumPool).GetInstance(0x4000c3f890, 0x29b9ee0?)
scanner-1  | 	/go/pkg/mod/github.com/klippa-app/go-pdfium@v1.14.0/single_threaded/single_threaded.go:63 +0x74
```
# Testing

Running this in my app removes the race conditions I was getting.

